### PR TITLE
fix formatting and parameter error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ VirusTotal Scan Script for API V3
 Interact with VT from your shell.  
   
 Required parameters: API token, Action to perform.  
-Usage example: ./vt-scan.sh -t <API TOKEN> -f <FILE PATH>  
+Usage example: `./vt-scan.sh -k <API TOKEN> -f <FILE PATH>`  
 
 	-k		API key for VirusTotal - REQUIRED.  
 	-f		FULL PATH to a file object for VT to scan.  


### PR DESCRIPTION
Just 2 minors:

* example call: it's `-k` for the api Key (not `-t` for a Token)
* example call: quote as code so `<>` are handled properly