### PR TITLE
add support for uploading big files (32M+)

### DIFF
--- a/vt-scan.sh
+++ b/vt-scan.sh
@@ -54,7 +54,7 @@ vt_bigfile() {
     APIKEY="$1"
     FILE="$2"
     local URL=$(curl -s --request GET --url "https://www.virustotal.com/api/v3/files/upload_url" --header "x-apikey: $APIKEY" | jq .data)
-    echo curl -s --request POST --url $URL --header "x-apikey: $APIKEY" --form "file=@$FILE"
+    curl -s --request POST --url $URL --header "x-apikey: $APIKEY" --form "file=@$FILE"
 }
 
 vt_url() {


### PR DESCRIPTION
files > 32M need a special upload URL. I adjusted `vt_file()` to check file size first (no need to have a big upload fail) and then use the corresponding path.

Note that `$URL` not being quoted in the `curl` call of `vt_bigfile` is intentional: `jq` already returns the string quoted.